### PR TITLE
Support join bit masks

### DIFF
--- a/src/bit_cuda/analysis.cu
+++ b/src/bit_cuda/analysis.cu
@@ -14,25 +14,27 @@ __global__ void analyze(Node nodes[], Transfer transfers[], bool* has_changed, i
         *has_changed = true;
 
     if(node_index < node_count){
-        nodes[node_index].data.data = 1; // Set taint constant to true
+        nodes[node_index].data = 1; // Set taint constant to true
+        
         bool is_changed = true;
+        BitVector last_joined = 0;
+        BitVector current = nodes[node_index].data;
 
         while(*has_changed){
             if(node_index == 0)
                 *has_changed = false;
-            long int new_data = 0;
+            BitVector joined_data = 0;
             //Join
             {
-                long int old_data = nodes[node_index].data.data;
-                new_data = old_data;
                 int pred_index = 0;
                 while (nodes[node_index].predecessor_index[pred_index] != -1){
-                    __syncthreads();
-                    new_data |= nodes[nodes[node_index].predecessor_index[pred_index]].data.data;
+                    joined_data |= nodes[nodes[node_index].predecessor_index[pred_index]].data;
                     ++pred_index;
                 }
 
-                is_changed |= old_data != new_data;
+                is_changed |= last_joined != joined_data;
+                last_joined = joined_data;
+                current |= joined_data & nodes[node_index].join_mask;
             }
 
             //Transfer
@@ -43,8 +45,8 @@ __global__ void analyze(Node nodes[], Transfer transfers[], bool* has_changed, i
                     int next_var = transfer->rhs[var_index];
                     while(next_var != -1){
 
-                        if((new_data & (1 << next_var)) != 0){
-                            new_data |= (1 << transfer->x);
+                        if((joined_data & (1 << next_var)) != 0){
+                            current |= (1 << transfer->x);
                             break;
                         }
                         ++var_index;
@@ -59,11 +61,13 @@ __global__ void analyze(Node nodes[], Transfer transfers[], bool* has_changed, i
                 }
 
 
-                nodes[node_index].data.data = new_data;
+                nodes[node_index].data = current;
                 *has_changed = true;
                 is_changed = false;
                 // __syncthreads();
             }
+            __syncthreads();
+            __threadfence();
         }
     }
 

--- a/src/bit_cuda/analysis.h
+++ b/src/bit_cuda/analysis.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <array>
+#include <limits>
 namespace bit_cuda{
 
 struct Transfer{ // x = y + z     { x, [y, z]}
@@ -8,13 +9,12 @@ struct Transfer{ // x = y + z     { x, [y, z]}
     int next_transfer_index = -1;
 };
 
-struct BitVector{
-    long int data;
-};
+using BitVector = int32_t;
 
 struct Node{
     Transfer transfer;
     int predecessor_index[5] = {-1,-1,-1,-1,-1};
+    BitVector join_mask = INT32_MAX;
     BitVector data;
 };
 

--- a/src/bit_cuda/bit_vector_converter.h
+++ b/src/bit_cuda/bit_vector_converter.h
@@ -10,7 +10,7 @@ void set_bit_cuda_state(BitCudaTransformer<std::set<std::string>>& transformer,
     {
         for (auto& [var_name, var_index] : transformer.variables)
         {
-            if((transformer.nodes[i].data.data >> var_index) & 1){
+            if((transformer.nodes[i].data >> var_index) & 1){
                 nodes[i]->state.insert(var_name);
             }
         }                

--- a/tests/test_transforms_matrix.cpp
+++ b/tests/test_transforms_matrix.cpp
@@ -28,8 +28,8 @@ TEST_CASE("bit cuda x=$ -> y=x") {
 
     bit_cuda::execute_analysis_no_transfers(&nodes[0], nodes.size());
 
-    CHECK_MESSAGE(nodes[0].data.data == 3, "First node results doesnt match");
-    CHECK_MESSAGE(nodes[1].data.data == 7, "Second node results doesnt match");
+    CHECK_MESSAGE(nodes[0].data == 3, "First node results doesnt match");
+    CHECK_MESSAGE(nodes[1].data == 7, "Second node results doesnt match");
 } 
 
 TEST_CASE("bit cuda multi transforms") {
@@ -48,7 +48,7 @@ TEST_CASE("bit cuda multi transforms") {
 
     bit_cuda::execute_analysis(&nodes[0], nodes.size(), &transfers[0], transfers.size());
 
-    CHECK_MESSAGE(nodes[0].data.data == 7, "First node results doesnt match");
+    CHECK_MESSAGE(nodes[0].data == 7, "First node results doesnt match");
 } 
 
 TEST_CASE("unit matrix") {


### PR DESCRIPTION
This PR adds a new `join_mask` field to each Node struct. This field is used to change what values can be joined.

It works such that if all bits are set to 1 every variable will be joined.
If all bits are set to 0 no bits are joined.

Even when no variables are joined they are still used to evaluate the taintness of expressions, this is done to support assignments like
`x = x + 5`