### PR TITLE
taint source id for bit-cuda

### DIFF
--- a/src/bit_cuda/bit_cuda_transformer.h
+++ b/src/bit_cuda/bit_cuda_transformer.h
@@ -12,7 +12,7 @@ public:
     std::vector<bit_cuda::Transfer> transfer_functions{};
     std::map<Node<LatticeType>*, int> node_to_index{};
     std::map<std::string, int> variables{};
-    std::vector<int> taint_sources{};
+    std::set<int> taint_sources{};
 
     BitCudaTransformer(std::set<std::string> progVariables){
         int i = 0;
@@ -34,7 +34,7 @@ public:
         bit_cuda::Node& node_struct = nodes.emplace_back();
 
         node_struct.first_transfer_index = add_transfer_function(node.id, node.expression);
-        add_id(id, transfer_functions[node_struct.first_transfer_index].rhs);
+        add_taint_source(id, transfer_functions[node_struct.first_transfer_index].rhs);
         node_struct.join_mask ^= 1 << variables[node.id];
     }
 
@@ -44,7 +44,7 @@ public:
         bit_cuda::Node& node_struct = nodes.emplace_back();
 
         node_struct.first_transfer_index = add_transfer_function(RETURN_VAR, node.expression);
-        add_id(id, transfer_functions[node_struct.first_transfer_index].rhs);
+        add_taint_source(id, transfer_functions[node_struct.first_transfer_index].rhs);
         node_struct.join_mask = 0;
     }
 
@@ -63,13 +63,13 @@ public:
 
         if(node.arguments.size() >= 1){
             node_struct.first_transfer_index = add_transfer_function(node.formal_parameters[0], node.arguments[0]);
-            add_id(id, transfer_functions[node_struct.first_transfer_index].rhs);
+            add_taint_source(id, transfer_functions[node_struct.first_transfer_index].rhs);
             bit_cuda::Transfer& last = transfer_functions[node_struct.first_transfer_index];
             
             for (int i = 1; i < node.arguments.size(); i++)
             {
                 last.next_transfer_index = add_transfer_function(node.formal_parameters[i], node.arguments[i]);
-                add_id(id, transfer_functions[last.next_transfer_index].rhs);
+                add_taint_source(id, transfer_functions[last.next_transfer_index].rhs);
                 last = transfer_functions[last.next_transfer_index];
             }
         }
@@ -81,7 +81,7 @@ public:
         bit_cuda::Node& node_struct = nodes.emplace_back();
 
         node_struct.first_transfer_index = add_transfer_function(node.id, {RETURN_VAR});
-        add_id(id, transfer_functions[node_struct.first_transfer_index].rhs);
+        add_taint_source(id, transfer_functions[node_struct.first_transfer_index].rhs);
         node_struct.join_mask ^= 1 << variables[node.id];
         node_struct.join_mask ^= 1 << variables[RETURN_VAR];
     }
@@ -92,7 +92,7 @@ public:
         bit_cuda::Node& node_struct = nodes.emplace_back();
 
         node_struct.first_transfer_index = add_transfer_function(node.id, node.expression);
-        add_id(id, transfer_functions[node_struct.first_transfer_index].rhs);
+        add_taint_source(id, transfer_functions[node_struct.first_transfer_index].rhs);
         node_struct.join_mask ^= 1 << variables[node.id];
     }
     
@@ -113,7 +113,7 @@ public:
         }
 
         node_struct.first_transfer_index = add_transfer_function(node.id, expr_vars);
-        add_id(id, transfer_functions[node_struct.first_transfer_index].rhs);
+        add_taint_source(id, transfer_functions[node_struct.first_transfer_index].rhs);
     }
 
     void visit_propagation(PropagationNode<LatticeType>& node) { 
@@ -147,11 +147,11 @@ private:
             }
         } 
     }
-    void add_id(int bitcudaId, int transfer[]){
+    void add_taint_source(int nodeIndex, int transfer[]){
         int size = sizeof(transfer)/sizeof(transfer[0]);
         for (int i = 0; i < size; i++){
             if(transfer[i] == variables[TAINT_VAR]){
-                taint_sources.push_back(bitcudaId);
+                taint_sources.insert(nodeIndex);
                 break;
             }
         }

--- a/src/bit_cuda/bit_cuda_transformer.h
+++ b/src/bit_cuda/bit_cuda_transformer.h
@@ -155,3 +155,23 @@ BitCudaTransformer<LatticeType> transform_bit_cuda(std::vector<std::shared_ptr<N
     add_predecessors(nodes, transformer);
     return transformer;
 }
+
+template<typename LatticeType>
+std::vector<int> taint_source_ids(BitCudaTransformer<LatticeType>& transformer){
+    std::vector<int> taint_node_ids;
+    int nodeindex = 0;
+
+    for(auto& node : transformer.nodes){
+        if(node.first_transfer_index != -1){
+            bit_cuda::Transfer transfer = transformer.transfer_functions[node.first_transfer_index];
+            for (auto& vars : transfer.rhs){
+                if(vars == transformer.variables[TAINT_VAR]){
+                    taint_node_ids.push_back(nodeindex);
+                    break;
+                }
+            }
+        }
+        ++nodeindex;
+    }
+    return taint_node_ids;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,8 @@ void bit_cuda_analysis(ScTransformer<std::set<std::string>> program){
     auto transformer = time_func<BitCudaTransformer<std::set<std::string>>>("Gpu structure transformation: ", 
                 transform_bit_cuda<std::set<std::string>>, program.nodes);
     
+    std::vector<int> taintnodesid = taint_source_ids(transformer); 
+    
     time_func("Least fixed point algorithm: ",
             bit_cuda::execute_analysis, &transformer.nodes[0], transformer.nodes.size(), &*transformer.transfer_functions.begin(), transformer.transfer_functions.size());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,9 +58,7 @@ void bit_cuda_analysis(ScTransformer<std::set<std::string>> program){
                 reduce_variables<std::set<std::string>>, program.entryNodes);
     auto transformer = time_func<BitCudaTransformer<std::set<std::string>>>("Gpu structure transformation: ", 
                 transform_bit_cuda<std::set<std::string>>, program.nodes);
-    
-    std::vector<int> taintnodesid = taint_source_ids(transformer); 
-    
+        
     time_func("Least fixed point algorithm: ",
             bit_cuda::execute_analysis, &transformer.nodes[0], transformer.nodes.size(), &*transformer.transfer_functions.begin(), transformer.transfer_functions.size());
 


### PR DESCRIPTION
added field `taint_sources` on BitCudaTransformer that stores the id of nodes containing a taint source